### PR TITLE
Wrapped value with addslashes.

### DIFF
--- a/src/Creator.php
+++ b/src/Creator.php
@@ -17,7 +17,7 @@ class Creator
             $iterable = iterator_to_array($iterable);
         }
         $middle = implode(PHP_EOL, array_map(function ($value, $key) {
-            return "\t"."'$key'".' => '."'$value',";
+            return "\t"."'$key' => '".addslashes($value)."',";
         }, $iterable, array_keys($iterable)));
 
         $end = PHP_EOL.'];';


### PR DESCRIPTION
Wrapped language tag value with a `addslashes()` tag, to fix an issue if the user has used a single quote in the language tag value field.